### PR TITLE
Move to always using two digits for months and days

### DIFF
--- a/data/experiences.ts
+++ b/data/experiences.ts
@@ -18,7 +18,7 @@ export const experiences: Experience[] = [
       location: "Pittsburgh, PA",
       link: "https://blastpoint.com/",
     },
-    startDate: new Date("2021-10-6"),
+    startDate: new Date("2021-10-06"),
     description: "",
   },
   {
@@ -28,8 +28,8 @@ export const experiences: Experience[] = [
       location: "Pittsburgh, PA",
       link: "https://brdg.ai/",
     },
-    startDate: new Date("2020-1-2"), // TODO: check this date
-    endDate: new Date("2021-10-6"),
+    startDate: new Date("2020-01-02"),
+    endDate: new Date("2021-10-06"),
     description:
       "Created UIs and designed developer-friendly APIs for machine learning pipeline. Projects included custom web-based image and video labeling software (react, canvas/konva), a cross-platform data collection mobile app (react native, Expo), and several dashboards. Helped manage a remote team of contractors located outside of the US. Heavily contributed to iterating devops workflow by spearheading implementing analytics, error reporting, and CI.",
   },
@@ -41,7 +41,7 @@ export const experiences: Experience[] = [
       // link: "https://eventdiscovery.company/", // site is dead
     },
     startDate: new Date("2017-10"), // TODO: get real date
-    endDate: new Date("2020-3-1"),
+    endDate: new Date("2020-03-01"),
     description:
       "Led communication with customers and stakeholders to make product and business decisions. Spearheaded frontend development, creating interactive wireframes in Adobe XD and implementing them in React via Material UI. Worked remote with a team through an always-improving agile development workflow.",
   },
@@ -52,8 +52,8 @@ export const experiences: Experience[] = [
       location: "Youngstown, OH",
       link: "https://drund.com/",
     },
-    startDate: new Date("2017-8"), // TODO: get real date
-    endDate: new Date("2018-9-14"),
+    startDate: new Date("2017-08"), // TODO: get real date
+    endDate: new Date("2018-09-14"),
     description:
       "Grew Drund's team and talent by coordinating internship programs, developer community outreach, and brand awareness.",
   },
@@ -64,8 +64,8 @@ export const experiences: Experience[] = [
       location: "Youngstown, OH",
       link: "https://drund.com/",
     },
-    startDate: new Date("2016-2-9"),
-    endDate: new Date("2018-9-14"),
+    startDate: new Date("2016-02-09"),
+    endDate: new Date("2018-09-14"),
     description:
       "Maintained and added features to a white-label social-network-as-a-service. Helped modernize the project by leading the implementation of Javascript code standards via linting, integration testing, unit testing, and refactoring.",
   },
@@ -76,8 +76,8 @@ export const experiences: Experience[] = [
       location: "Cleveland, OH",
       link: "http://flashstarts.com/",
     },
-    startDate: new Date("2015-5-19"),
-    endDate: new Date("2015-8-19"),
+    startDate: new Date("2015-05-19"),
+    endDate: new Date("2015-08-19"),
     description:
       "Spent three months helping ten-odd startups get their MVPs ready in time for Demo Day in Flashstarts' intensive program. Learned a ton about sales and entrepreneurship along the way. Worked simultaneously on multiple projects with multiple teams. Worked with the MEAN stack on one project, and Phaser.js using Typescript on another. Discovered the wonderful thing that is UX testing.",
   },
@@ -88,8 +88,8 @@ export const experiences: Experience[] = [
       location: "Youngstown, OH",
       link: "https://ysu.edu/",
     },
-    startDate: new Date("2013-9"), // TODO: get real date
-    endDate: new Date("2015-2"), // TODO: get real date
+    startDate: new Date("2013-09"), // TODO: get real date
+    endDate: new Date("2015-02"), // TODO: get real date
     description:
       "Created an information organization system for the Youngstown State University's Undergraduate web Bulletin. This involved writing custom Drupal plugins and themes in PHP.",
   },


### PR DESCRIPTION
Move to always using two digits for months and days to fix rendering the site in Safari