### PR TITLE
Various visual fixes + Install SimpleAnalytics

### DIFF
--- a/components/experiences.tsx
+++ b/components/experiences.tsx
@@ -26,12 +26,14 @@ function Experience({ experience }: { experience: ExperienceType }) {
           <span className="block">{company.location}</span>
 
           <span className="block">
-            <time dateTime={startDate.toISOString()}>
+            {/* Inline-block helps not break between years and months on mobile, see
+            https://stackoverflow.com/questions/18222409/specifying-a-preferred-line-break-point-in-html-text-in-a-responsive-design */}
+            <time dateTime={startDate.toISOString()} className="inline-block">
               {format(startDate, "MMM y")}
             </time>{" "}
             -{" "}
             {endDate ? (
-              <time dateTime={endDate.toISOString()}>
+              <time dateTime={endDate.toISOString()} className="inline-block">
                 {format(endDate, "MMM y")}
               </time>
             ) : (

--- a/components/experiences.tsx
+++ b/components/experiences.tsx
@@ -8,7 +8,7 @@ function Experience({ experience }: { experience: ExperienceType }) {
 
   return (
     <li className="mb-2">
-      <div className="flex mb-1">
+      <div className="flex mb-1 gap-4">
         <div className="flex-grow">
           <h4>
             <b>{title}</b> @<br />

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -98,7 +98,7 @@ export default function Layout({
 
         <div className="text-center flex-1">
           <a
-            href="https://github.com/JoeDuncko/JoeDuncko.github.io"
+            href="https://github.com/JoeDuncko/joeduncko.com"
             className="m-1"
             target="_blank"
           >

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -89,7 +89,7 @@ export default function Layout({
           </Link>
         </div>
       )}
-      <footer className="max-w-screen-lg sm:flex text-xs print:hidden">
+      <footer className="max-w-screen-lg sm:flex text-xs print:hidden items-center">
         <div className="text-center sm:text-left flex-1">
           {/* Fix height */}
           <FontAwesomeIcon icon={faCopyright} /> Joe Duncko{" "}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,19 @@
+import { Head, Html, Main, NextScript } from "next/document";
+
+export default function Document() {
+  return (
+    <Html>
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+
+        {/* SimpleAnalytics */}
+        <script async defer src="https://sa.joeduncko.com/latest.js"></script>
+        <noscript>
+          <img src="https://sa.joeduncko.com/noscript.gif" alt="" />
+        </noscript>
+      </body>
+    </Html>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -51,7 +51,7 @@ export default function Home({
           </div>
         </div>
 
-        <div className="flex flex-col md:flex-row print:flex-row gap-8">
+        <div className="flex flex-col md:flex-row print:flex-row md:gap-8">
           <div className="flex-1">
             <Experiences />
           </div>


### PR DESCRIPTION
Includes the following fixes:
- Don't show gab between columns on mobile
- Fix repo link
- Don't break between experience year and month on mobile
- Add minimum gap between experience title and dates
- Align footer items center
- Install SimpleAnalytics